### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-06
+
 ### Added
 
 - MIT `LICENSE` file.
 - `GH_PATH` environment variable to specify a custom path to the `gh` binary (defaults to `gh` on `PATH`).
+- Unit tests for `index.ts` handler logic.
 
 ### Removed
 
@@ -41,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Dependabot configuration for weekly npm dependency updates.
 - 34 unit tests covering validation and help flag handling.
 
-[Unreleased]: https://github.com/jarrettmeyer/gh-mcp/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/jarrettmeyer/gh-mcp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/jarrettmeyer/gh-mcp/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/jarrettmeyer/gh-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/jarrettmeyer/gh-mcp/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A simple MCP wrapper around the 'gh' CLI.",
   "type": "module",
   "author": {


### PR DESCRIPTION
## Summary

- Bump `version` in `package.json` to `0.2.0`
- Promote `[Unreleased]` entries to `[0.2.0] - 2026-04-06` in `CHANGELOG.md`
- Add fresh empty `[Unreleased]` section
- Update changelog comparison links

## Test plan

- [ ] All 31 unit tests pass (`bun test`)
- [ ] TypeScript compiles cleanly (`bun run typecheck`)
- [x] Formatting is correct (`bun run format:check`)
- [ ] After merge, create and push `v0.2.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)