### PR TITLE
docs: fix README typos and expand installation/usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- bun run /path/to/gh-mcp/
 
 ### `send_command`
 
-Executes a `gh` CLI command. Pass everything that would follow `gh` on the command line as the `command` string.
+Execute a `gh` CLI command. Pass everything that would follow `gh` on the command line as the `command` string.
 
 | Parameter | Type   | Description                              |
 | --------- | ------ | ---------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "gh": {
-      "command": "/path/to/.bun/bin/bun",
+      "command": "/Users/your-username/.bun/bin/bun",
       "args": ["run", "/path/to/gh-mcp/src/index.ts"]
     }
   }
@@ -63,13 +63,13 @@ Then restart Claude Desktop.
 Install from your terminal:
 
 ```bash
-claude mcp add gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+claude mcp add gh -- ~/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
 ```
 
 If `gh` is in a non-standard location, pass `GH_PATH` via `--env`:
 
 ```bash
-claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- ~/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
 ```
 
 ## Usage
@@ -107,7 +107,7 @@ By default, the server resolves `gh` from your `PATH`. If `gh` is installed in a
 {
   "mcpServers": {
     "gh": {
-      "command": "/path/to/.bun/bin/bun",
+      "command": "/Users/your-username/.bun/bin/bun",
       "args": ["run", "/path/to/gh-mcp/src/index.ts"],
       "env": {
         "GH_PATH": "/opt/homebrew/bin/gh"

--- a/README.md
+++ b/README.md
@@ -15,52 +15,89 @@ The server prevents shell injection by design — commands are passed as argumen
 
 ## Installation
 
-1. Install the [GitHub CLI](https://cli.github.com/)
+### 1. Install the GitHub CLI
 
-2. Verify your `gh` installation
+Download the [GitHub CLI](https://cli.github.com/). Or use `brew install gh`. Verify your installation.
 
-   ```bash
-   gh --version
-   ```
+```bash
+gh --version
+```
 
-3. Install [bun](https://bun.com/docs/installation)
+### 2. Install bun
 
-4. Verify your `bun` installation
+This project uses [bun](https://bun.com/docs/installation) for package management. Verify your installation.
 
-   ```bash
-   bun --version
-   ```
+```bash
+bun --version
+```
 
-5. Add the server to your MCP client
+### 3. Clone the repo and install dependencies
 
-   **Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+```bash
+git clone https://github.com/jarrettmeyer/gh-mcp.git
+cd gh-mcp
+bun install
+```
 
-   ```json
-   {
-     "mcpServers": {
-       "gh": {
-         "command": "/path/to/.bun/bin/bun",
-         "args": ["run", "/path/to/gh-mcp/src/index.ts"]
-       }
-     }
-   }
-   ```
+### 4. Add the server to your MCP client
 
-   Then restart Claude Desktop.
+#### Claude Desktop
 
-   **Claude Code** — run from your terminal:
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
-   ```bash
-   claude mcp add gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
-   ```
+```json
+{
+  "mcpServers": {
+    "gh": {
+      "command": "/path/to/.bun/bin/bun",
+      "args": ["run", "/path/to/gh-mcp/src/index.ts"]
+    }
+  }
+}
+```
 
-   If `gh` is in a non-standard location, pass `GH_PATH` via `--env`:
+Then restart Claude Desktop.
 
-   ```bash
-   claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
-   ```
+#### Claude Code
 
-## Configuration
+Install from your terminal:
+
+```bash
+claude mcp add gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+```
+
+If `gh` is in a non-standard location, pass `GH_PATH` via `--env`:
+
+```bash
+claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+```
+
+## Usage
+
+### `send_command`
+
+Executes a `gh` CLI command. Pass everything that would follow `gh` on the command line as the `command` string.
+
+| Parameter | Type   | Description                              |
+| --------- | ------ | ---------------------------------------- |
+| `command` | string | The `gh` subcommand and arguments to run |
+
+**Examples:**
+
+```text
+List open pull requests in a repo:
+  command: "pr list --repo owner/repo"
+
+View an issue:
+  command: "issue view 42 --repo owner/repo"
+
+Check the authenticated user:
+  command: "auth status"
+```
+
+This tool works with any MCP-compatible client, including Claude Desktop, Claude Code, and Cursor.
+
+## Additional Configuration
 
 ### `GH_PATH`
 
@@ -79,33 +116,6 @@ By default, the server resolves `gh` from your `PATH`. If `gh` is installed in a
   }
 }
 ```
-
-## Usage
-
-This server exposes a single MCP tool:
-
-### `send_command`
-
-Executes a `gh` CLI command. Pass everything that would follow `gh` on the command line as the `command` string.
-
-| Parameter | Type   | Description                              |
-| --------- | ------ | ---------------------------------------- |
-| `command` | string | The `gh` subcommand and arguments to run |
-
-**Examples:**
-
-```
-List open pull requests in a repo:
-  command: "pr list --repo owner/repo"
-
-View an issue:
-  command: "issue view 42 --repo owner/repo"
-
-Check the authenticated user:
-  command: "auth status"
-```
-
-This tool works with any MCP-compatible client, including Claude Desktop, Claude Code, and Cursor.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ bun install
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
+**Note**: `bun` installs to `~/.bun/bin/`, which is not on the default `PATH`. Use the full path to the `bun` executable.
+
 ```json
 {
   "mcpServers": {
@@ -55,8 +57,6 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
   }
 }
 ```
-
-**Note**: `bun` installs to `~/.bun/bin/`. This is not part of any default path, thus requiring the full path to the `bun` executable.
 
 Then restart Claude Desktop.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
-Then restart Claude Desktop.
+Restart Claude Desktop.
 
 #### Claude Code
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
+**Note**: `bun` installs to `~/.bun/bin/`. This is not part of any default path, thus requiring the full path to the `bun` executable.
+
 Then restart Claude Desktop.
 
 #### Claude Code
@@ -63,13 +65,13 @@ Then restart Claude Desktop.
 Install from your terminal:
 
 ```bash
-claude mcp add gh -- ~/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+claude mcp add gh -- bun run /path/to/gh-mcp/src/index.ts
 ```
 
 If `gh` is in a non-standard location, pass `GH_PATH` via `--env`:
 
 ```bash
-claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- ~/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- bun run /path/to/gh-mcp/src/index.ts
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The server prevents shell injection by design — commands are passed as argumen
 
 2. Verify your `gh` installation
 
-   ```bah
+   ```bash
    gh --version
    ```
 
@@ -31,9 +31,9 @@ The server prevents shell injection by design — commands are passed as argumen
    bun --version
    ```
 
-5. Update your Claude Desktop configuration
+5. Add the server to your MCP client
 
-   On MacOS, this is located at `~/Application Support/Claude/claude_desktop_config.json`.
+   **Claude Desktop** — edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
    ```json
    {
@@ -46,7 +46,19 @@ The server prevents shell injection by design — commands are passed as argumen
    }
    ```
 
-6. Restart Claude Desktop
+   Then restart Claude Desktop.
+
+   **Claude Code** — run from your terminal:
+
+   ```bash
+   claude mcp add gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+   ```
+
+   If `gh` is in a non-standard location, pass `GH_PATH` via `--env`:
+
+   ```bash
+   claude mcp add gh --env GH_PATH=/opt/homebrew/bin/gh -- /path/to/.bun/bin/bun run /path/to/gh-mcp/src/index.ts
+   ```
 
 ## Configuration
 
@@ -67,6 +79,33 @@ By default, the server resolves `gh` from your `PATH`. If `gh` is installed in a
   }
 }
 ```
+
+## Usage
+
+This server exposes a single MCP tool:
+
+### `send_command`
+
+Executes a `gh` CLI command. Pass everything that would follow `gh` on the command line as the `command` string.
+
+| Parameter | Type   | Description                              |
+| --------- | ------ | ---------------------------------------- |
+| `command` | string | The `gh` subcommand and arguments to run |
+
+**Examples:**
+
+```
+List open pull requests in a repo:
+  command: "pr list --repo owner/repo"
+
+View an issue:
+  command: "issue view 42 --repo owner/repo"
+
+Check the authenticated user:
+  command: "auth status"
+```
+
+This tool works with any MCP-compatible client, including Claude Desktop, Claude Code, and Cursor.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Fixes two typos from #9: `` ```bah `` → `` ```bash ``, and `~/Application Support/Claude/` → `~/Library/Application Support/Claude/`
- Addresses #14: adds a **Usage** section documenting the `send_command` tool name, its `command` input parameter, and example invocations
- Adds **Claude Code** installation instructions (`claude mcp add`) alongside the existing Claude Desktop JSON config step

## Test plan

- [x] `bun test` — 31 tests pass
- [x] `bun run typecheck` — no type errors
- [x] `bun run format:check` — Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)